### PR TITLE
Use sub claim in README to load resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ end
 Accessing the resource from a set of claims:
 
 ```elixir
-case Guardian.serializer.from_token(claims) do
+case Guardian.serializer.from_token(claims.sub) do
   { :ok, resource } -> do_things_with_resource(resource)
   { :error, reason } -> do_things_without_a_resource(reason)
 end


### PR DESCRIPTION
In the above example, the serializer is designed to only take input from the sub field. While you could also implement a pattern to load a resource from the full claim set, I think this is the intended and most common way.