### PR TITLE
Remove `plug :action` from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ defmodule MyApp.SessionController do
   alias MyApp.UserQuery
 
   plug :scrub_params, "user" when action in [:create]
-  plug :action
 
   def create(conn, params = %{}) do
     conn


### PR DESCRIPTION
This has caused some confusion as the action plug is now called for you
automatically in Phoenix.

@hassox is there any way you could update this blog post to remove it as well? https://hassox.github.io/elixir/guardian/2015/06/30/api-authentication-with-guardian.html