### PR TITLE
Fix two bugs with api_sign_in

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -136,7 +136,7 @@ defmodule Guardian.Plug do
         |> set_current_token(jwt, the_key)
         |> Guardian.hooks_module.after_sign_in(the_key)
 
-      { :error, reason } -> set_claims(conn, base_key(the_key), { :error, reason }) # TODO: handle this failure
+      { :error, reason } -> set_claims(conn, { :error, reason }, the_key) # TODO: handle this failure
     end
   end
 

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -86,7 +86,7 @@ defmodule Guardian.Plug do
         conn
         |> Plug.Conn.put_session(base_key(the_key), jwt)
         |> set_current_resource(object, the_key)
-        |> set_claims(full_claims, the_key)
+        |> set_claims({ :ok, full_claims }, the_key)
         |> set_current_token(jwt, the_key)
         |> Guardian.hooks_module.after_sign_in(the_key)
 
@@ -132,7 +132,7 @@ defmodule Guardian.Plug do
       { :ok, jwt, full_claims } ->
         conn
         |> set_current_resource(object, the_key)
-        |> set_claims(full_claims, the_key)
+        |> set_claims({ :ok, full_claims }, the_key)
         |> set_current_token(jwt, the_key)
         |> Guardian.hooks_module.after_sign_in(the_key)
 

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -198,6 +198,17 @@ defmodule Guardian.PlugTest do
     assert claims["here"] == "we are"
   end
 
+  test "api_sign_in(object) error", context do
+    conn = context.conn
+    |> Guardian.Plug.api_sign_in(%{error: :unknown})
+
+    claims = conn.assigns[Guardian.Keys.claims_key]
+
+    assert {:error, _reason} = claims
+    assert conn.assigns[Guardian.Keys.resource_key] == nil
+    assert conn.assigns[Guardian.Keys.jwt_key] == nil
+  end
+
   test "api_sign_in(object)", context do
     conn = context.conn
     |> Guardian.Plug.api_sign_in(%{user: "here"})

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -181,6 +181,9 @@ defmodule Guardian.PlugTest do
     { :ok, claims } = Guardian.decode_and_verify(jwt)
 
     assert claims["sub"]["user"] == "here"
+
+    { :ok, claims} = Guardian.Plug.claims(conn)
+    assert claims
   end
 
   test "sign_in(object, type, claims)", context do
@@ -230,6 +233,9 @@ defmodule Guardian.PlugTest do
     { :ok, claims } = Guardian.decode_and_verify(jwt)
 
     assert claims["sub"]["user"] == "here"
+
+    { :ok, claims} = Guardian.Plug.claims(conn)
+    assert claims
   end
 
   test "api_sign_in(object, type, claims)", context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,7 @@
 defmodule Guardian.TestGuardianSerializer do
   @behaviour Guardian.Serializer
+  def for_token(%{error: :unknown}), do: { :error, "Unknown resource type" }
+
   def for_token(aud), do: { :ok, aud }
   def from_token(aud), do: { :ok, aud }
 end


### PR DESCRIPTION
Hi @hassox.  I started digging into the `api_sign_in` code after seeing #55 and along the way I found two bugs which the PR fixes including the original issue:

+ The parameters for `set_claims` during errors were mixed up.  I re-ordered them and added a test case.
+ Neither `sign_in` or `api_sign_in` were passing the expected tuple to `set_claims`.  Closes #55 