### PR TITLE
Move on_failure to a handler module

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If one is not found, this does nothing.
 ### Guardian.Plug.EnsureAuthenticated
 
 Looks for a previously verified token. If one is found, continues, otherwise it
-will call the `:on_failure` function.
+will call the `:unauthenticated` function of your handler.
 
 When you ensure a session, you must declare an error handler. This can be done
 as part of a pipeline or inside a pheonix controller.
@@ -101,23 +101,39 @@ as part of a pipeline or inside a pheonix controller.
 defmodule MyApp.MyController do
   use MyApp.Web, :controller
 
-  plug Guardian.Plug.EnsureAuthenticated, on_failure: { MyApp.MyController, :unauthenticated }
+  plug Guardian.Plug.EnsureAuthenticated, handler: MyApp.MyAuthErrorHandler
 end
 ```
 
 The failure function must receive the connection, and the connection params.
 
+The error handler may be defined inline or in the main configuration.
+
+```elixir
+config :guardian, Guardian,
+  handler: MyApp.MyAuthErrorHandler
+  # …
+```
+
 ### Guardian.Plug.EnsurePermissions
 
 Looks for a previously verified token. If one is found, confirms that all listed
-permissions are present in the token. If not, the failure function is called.
+permissions are present in the token. If not, the `:unauthorized` function is called on your handler.
 
 ```elixir
 defmodule MyApp.MyController do
   use MyApp.Web, :controller
 
-  plug Guardian.Plug.EnsurePermissions, on_failure: { MyApp.MyController, :forbidden }, default: [:read, :write]
+  plug Guardian.Plug.EnsurePermissions, handler: MyApp.MyAuthErrorHandler, default: [:read, :write]
 end
+```
+
+The error handler may be defined inline or in the main configuration.
+
+```elixir
+config :guardian, Guardian,
+  handler: MyApp.MyAuthErrorHandler
+  # …
 ```
 
 ### Pipelines
@@ -152,7 +168,7 @@ From here, you can either EnsureAuthenticated in your pipeline, or on a per-cont
 defmodule MyApp.MyController do
   use MyApp.Web, :controller
 
-  plug Guardian.Plug.EnsureAuthenticated, on_failure: { MyApp.MyHandler, :unauthenticated }
+  plug Guardian.Plug.EnsureAuthenticated, handler: MyApp.MyAuthHandler
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,6 @@ end
 
 The failure function must receive the connection, and the connection params.
 
-The error handler may be defined inline or in the main configuration.
-
-```elixir
-config :guardian, Guardian,
-  handler: MyApp.MyAuthErrorHandler
-  # …
-```
-
 ### Guardian.Plug.EnsurePermissions
 
 Looks for a previously verified token. If one is found, confirms that all listed
@@ -126,14 +118,6 @@ defmodule MyApp.MyController do
 
   plug Guardian.Plug.EnsurePermissions, handler: MyApp.MyAuthErrorHandler, default: [:read, :write]
 end
-```
-
-The error handler may be defined inline or in the main configuration.
-
-```elixir
-config :guardian, Guardian,
-  handler: MyApp.MyAuthErrorHandler
-  # …
 ```
 
 ### Pipelines

--- a/lib/guardian/plug/ensure_authenticated.ex
+++ b/lib/guardian/plug/ensure_authenticated.ex
@@ -12,14 +12,8 @@ defmodule Guardian.Plug.EnsureAuthenticated do
 
   The handler option may be passed. By default Guardian.Plug.ErrorHandler is used and the `:unauthenticated` function will be called.
 
-  The handler will be called on failure. You may specify the handler inline as
-  in the above example or in the global configuration.
+  The handler will be called on failure.
   The `:unauthenticated` function will be called when a failure is detected.
-
-  ```elixir
-  config :guardian, Guardian,
-    handler: MyHandler
-    # …
   """
   require Logger
   import Plug.Conn
@@ -35,8 +29,7 @@ defmodule Guardian.Plug.EnsureAuthenticated do
           {mod, f} ->
             Logger.log(:warn, "on_failure is deprecated. Use handler instead")
             {mod, f}
-          _ ->
-            {Guardian.config(:handler, Guardian.Plug.ErrorHandler), :unauthenticated}
+        _ -> raise "Requires a handler module to be passed"
         end
     end
 

--- a/lib/guardian/plug/ensure_permissions.ex
+++ b/lib/guardian/plug/ensure_permissions.ex
@@ -11,14 +11,8 @@ defmodule Guardian.Plug.EnsurePermissions do
 
   On failure will be handed the connection with the conn, and params where reason: :forbidden
 
-  The handler will be called on failure. You may specify the handler inline as
-  in the above example or in the global configuration.
+  The handler will be called on failure.
   The `:unauthorized` function will be called when a failure is detected.
-
-  ```elixir
-  config :guardian, Guardian,
-    handler: MyHandler
-    # …
   """
 
   require Logger
@@ -38,7 +32,7 @@ defmodule Guardian.Plug.EnsurePermissions do
         {mod, f} ->
           Logger.log(:warn, "on_failure is deprecated. Use handler")
           {mod, f}
-        _ -> {Guardian.config(:handler, Guardian.Plug.ErrorHandler), :unauthorized}
+        _ -> raise "Requires a handler module to be passed"
       end
     end
 

--- a/lib/guardian/plug/error_handler.ex
+++ b/lib/guardian/plug/error_handler.ex
@@ -1,0 +1,52 @@
+defmodule Guardian.Plug.ErrorHandler do
+  @callback unauthenticated(Plug.t, Map.t) :: Plug.t
+  @callback unauthorized(Plug.t, Map.t) :: Plug.t
+
+  import Plug.Conn
+
+  def unauthenticated(conn, _params) do
+    respond(conn, accept_type(conn), 401, "Unauthenticated")
+  end
+
+  def unauthorized(conn, _params) do
+    respond(conn, accept_type(conn), 403, "Unauthorized")
+  end
+
+  defp respond(conn, :json, status, msg) do
+    try do
+      conn
+      |> configure_session(drop: true)
+      |> put_resp_content_type("application/json")
+      |> send_resp(status, Poison.encode!(%{errors: [msg]}))
+    rescue ArgumentError ->
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(status, Poison.encode!(%{errors: [msg]}))
+    end
+  end
+
+  defp respond(conn, :html, status, msg) do
+    try do
+      conn
+      |> configure_session(drop: true)
+      |> put_resp_content_type("text/plain")
+      |> send_resp(status, msg)
+    rescue ArgumentError ->
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(status, msg)
+    end
+  end
+
+  defp accept_type(conn) do
+    accept = conn
+    |> get_req_header(:accept)
+    |> List.wrap
+    |> hd
+
+    cond do
+      Regex.match?(~r/json/, accept) -> :json
+      true -> :html
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Guardian.Mixfile do
   use Mix.Project
 
-  @version "0.7.4"
+  @version "0.8.0"
 
   def project do
     [

--- a/test/guardian/plug/ensure_authenticated_test.exs
+++ b/test/guardian/plug/ensure_authenticated_test.exs
@@ -13,29 +13,21 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
     end
   end
 
-  @expected_failure { TestHandler, :unauthenticated }
-  @failure %{ on_failure: @expected_failure }
-
-  test "it requires an on_failure option" do
-    assert_raise RuntimeError, fn ->
-      EnsureAuthenticated.init([])
-    end
-
-    assert %{ on_failure: @expected_failure, claims: %{}, key: :default } == EnsureAuthenticated.init(@failure)
-  end
+  @expected_failure TestHandler
+  @failure %{ handler: {@expected_failure, :unauthenticated}}
 
   test "it validates claims and calls through if the claims are ok" do
     claims = %{ "aud" => "token", "sub" => "user1" }
     conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
-    opts = EnsureAuthenticated.init(on_failure: @expected_failure, aud: "token")
+    opts = EnsureAuthenticated.init(handler: @expected_failure, aud: "token")
     ensured_conn = EnsureAuthenticated.call(conn, opts)
     assert ensured_conn.assigns[:guardian_spec] == nil
   end
 
   test "it validates claims and fails if the claims do not match" do
     claims = %{ "aud" => "oauth", "sub" => "user1" }
-    conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
-    opts = EnsureAuthenticated.init(%{ on_failure: @expected_failure, aud: "token" })
+    conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key, {:ok, claims})
+    opts = EnsureAuthenticated.init(handler: @expected_failure, aud: "token")
     ensured_conn = EnsureAuthenticated.call(conn, opts)
     assert ensured_conn.assigns[:guardian_spec] == :unauthenticated
   end
@@ -49,12 +41,12 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
 
   test "it does not call on failure when there is a session at the specific location" do
     claims = %{ "aud" => "token", "sub" => "user1" }
-    conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key(:secret), { :ok, claims })
-    ensured_conn = EnsureAuthenticated.call(conn, %{ on_failure: @expected_failure, key: :secret })
+    conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key(:secret), {:ok, claims})
+    ensured_conn = EnsureAuthenticated.call(conn, %{handler: {@expected_failure, :unauthenticated}, key: :secret})
     assert ensured_conn.assigns[:guardian_spec] == nil
   end
 
-  test "it calls the on_failiure function when there is no session at default" do
+  test "it calls the handler unauthenticated function when there is no session at default" do
     conn = conn(:get, "/foo")
     ensured_conn = EnsureAuthenticated.call(conn, @failure)
     assert ensured_conn.assigns[:guardian_spec] == :unauthenticated
@@ -62,13 +54,13 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
 
   test "it calls the on_failiure function when there is no session at a specific location" do
     conn = conn(:get, "/foo")
-    ensured_conn = EnsureAuthenticated.call(conn, %{ on_failure: @expected_failure, key: :secret })
+    ensured_conn = EnsureAuthenticated.call(conn, %{handler: {@expected_failure, :unauthenticated}, key: :secret})
     assert ensured_conn.assigns[:guardian_spec] == :unauthenticated
   end
 
   test "it halts the connection" do
     conn = conn(:get, "/foo")
-    ensured_conn = EnsureAuthenticated.call(conn, %{ on_failure: @expected_failure, key: :secret })
+    ensured_conn = EnsureAuthenticated.call(conn, %{ handler: {@expected_failure, :unauthenticated}, key: :secret })
     assert ensured_conn.halted == true
   end
 end

--- a/test/guardian/plug/ensure_permissions_test.exs
+++ b/test/guardian/plug/ensure_permissions_test.exs
@@ -6,21 +6,15 @@ defmodule Guardian.Plug.EnsurePermissionTest do
   alias Guardian.Plug.EnsurePermissions
 
   defmodule TestHandler do
-    def forbidden(conn, _) do
+    def unauthorized(conn, _) do
       conn
       |> Plug.Conn.assign(:guardian_spec, :forbidden)
       |> Plug.Conn.send_resp(401, "Unauthorized")
     end
   end
 
-  @expected_failure { TestHandler, :forbidden }
-  @failure [on_failure: @expected_failure]
-
-  test "it requires an on_failure option" do
-    assert_raise RuntimeError, fn ->
-      EnsurePermissions.init([])
-    end
-  end
+  @expected_failure TestHandler
+  @failure [handler: @expected_failure]
 
   test "does not call the on failure when the permissions are present" do
     opts = EnsurePermissions.init(@failure ++ [ default: [:read, :write] ])


### PR DESCRIPTION
The on\_failure was pretty verbose. This PR moves that to a simple handler that should define 
`:unauthenticated` and `:unauthorized` function instead.

ping @chrismccord