### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ case Guardian.refresh!(existing_jwt, exisiting_claims, %{ttl: {15, :days}}) do
   {:ok, new_jwt, new_claims} -> do_things(new_jwt)
   {:error, reason} -> handle_error(reason)
 end
+```
 
 Once the new token is created, the old one is revoked before returning the new
 token.
@@ -492,7 +493,7 @@ feedback to get up and running.
 - [x] Integration with Plug
 - [x] Basic integrations like raw TCP
 - [x] Sevice2Service credentials. That is, pass the authentication results through many downstream requests.
-- [-] Create a "csrf" token type that ensures that CSRF protection is included
+- [ ] Create a "csrf" token type that ensures that CSRF protection is included
 - [x] Integration with Phoenix channels
 - [x] Integrated permission sets
 - [x] Hooks into the authentication cycle


### PR DESCRIPTION
This addresses two minor formatting issues in the README.

- Add mising triple backticks to close code block
- Fix todo list formatting