### PR TITLE
remove printing to console on error, just return the exception

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -188,8 +188,7 @@ defmodule Guardian do
       end
     rescue
       e ->
-        IO.puts(Exception.format_stacktrace(System.stacktrace))
-        { :error, e.message }
+        { :error, e }
     end
   end
 


### PR DESCRIPTION
Very small change but it really bugged me.
Also the real problem is that the JOSE library has a bug that throws the exception in the first place. Hopefully I'll find some time to open PR for that also.