### PR TITLE
Adding uppercase string sigil to moduledoc

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -1,5 +1,5 @@
 defmodule Guardian do
-  @moduledoc """
+  @moduledoc ~S"""
   Guardian provides a singular interface for authentication in Elixir applications
   that is `token` based.
 


### PR DESCRIPTION
To escape the default argument operator, otherwise ExDoc renders things like "refresh(token, opts \ [])"