### PR TITLE
Fix the ex_doc warning caused by Guardian.Permissions

### DIFF
--- a/lib/guardian/permissions.ex
+++ b/lib/guardian/permissions.ex
@@ -181,7 +181,7 @@ defmodule Guardian.Permissions do
 
       @doc """
       Decodes permissions directly from a claims map. This does the same as `decode_permissions` but
-      will fetch the permissions map from the `"pem"` key where `Guardian.Permissions places them
+      will fetch the permissions map from the `"pem"` key where `Guardian.Permissions` places them
       when it encodes them into claims.
       """
       @spec decode_permissions_from_claims(Guardian.Token.claims()) :: Guardian.Permissions.t()


### PR DESCRIPTION
When I use Guardian.Permissions in my module and try to use `mix doc` to generate documents, I encountered a warning:

```
warning: Closing unclosed backquotes ` at end of input.
```

After troubleshooting, I found it's caused by line 185 of `Guardian.Permissions`

This commit fixes this doc typo