### PR TITLE
Fix Mix 1.20 deprecations and add Elixir 1.20 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
             otp: "28"
           - elixir: "1.19"
             otp: "29"
+          - elixir: "1.20"
+            otp: "29"
     env:
       MIX_ENV: test
     steps:

--- a/mix.exs
+++ b/mix.exs
@@ -28,14 +28,14 @@ defmodule Guardian.Mixfile do
       homepage_url: @url,
       docs: docs(),
       deps: deps(),
-      xref: [exclude: [:phoenix]],
+      elixirc_options: [no_warn_undefined: [Phoenix]],
       dialyzer: dialyxir(),
-      test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.html": :test
-      ]
+      test_coverage: [tool: ExCoveralls]
     ]
+  end
+
+  def cli do
+    [preferred_envs: [coveralls: :test, "coveralls.html": :test]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
Resolves two deprecation warnings emitted by Elixir 1.20.x and broadens CI coverage to the latest Elixir/OTP combination.

## Changes

### `mix.exs`

- Move `preferred_cli_env` out of `def project` into a new `def cli` block, using the renamed `preferred_envs` key.
- Replace the deprecated `xref: [exclude: [:phoenix]]` with `elixirc_options: [no_warn_undefined: [Phoenix]]`, which is the supported replacement in Mix 1.20.

### `.github/workflows/ci.yml`

- Add Elixir 1.20 / OTP 29 to the test matrix, matching the latest supported combination on the CI runner images.